### PR TITLE
add support and tests for spacing between DELETE keywords

### DIFF
--- a/dist/keywords.js
+++ b/dist/keywords.js
@@ -165,15 +165,15 @@ exports.keywords = {
     }),
     INSERT_DATA: chevrotain_1.createToken({
         name: 'INSERT_DATA',
-        pattern: /Insert Data/i,
+        pattern: /Insert +Data/i,
     }),
     DELETE_DATA: chevrotain_1.createToken({
         name: 'DELETE_DATA',
-        pattern: /Delete Data/i,
+        pattern: /Delete +Data/i,
     }),
     DELETE_WHERE: chevrotain_1.createToken({
         name: 'DELETE_WHERE',
-        pattern: /Delete Where/i,
+        pattern: /Delete +Where/i,
     }),
     WITH: chevrotain_1.createToken({
         name: 'WITH',

--- a/src/__tests__/fixtures/sparql11/ebnf/goodDog/prose7a
+++ b/src/__tests__/fixtures/sparql11/ebnf/goodDog/prose7a
@@ -1,0 +1,7 @@
+INSERT      DATA
+  { 
+    GRAPH <urn:sparql:tests:insert:data> 
+      { 
+        <#book1> <#price> 42 
+      } 
+  }

--- a/src/__tests__/fixtures/sparql11/ebnf/goodDog/prose7b
+++ b/src/__tests__/fixtures/sparql11/ebnf/goodDog/prose7b
@@ -1,0 +1,5 @@
+DELETE      DATA
+  {
+    <#book2> <http://purl.org/dc/elements/1.1/title>   "David Copperfield" ; 
+             <http://purl.org/dc/elements/1.1/creator> "Edmund Wells"      .
+  }

--- a/src/__tests__/fixtures/sparql11/ebnf/goodDog/prose7c
+++ b/src/__tests__/fixtures/sparql11/ebnf/goodDog/prose7c
@@ -1,0 +1,12 @@
+DELETE      WHERE 
+  {
+    GRAPH <urn:sparql:tests:delete:where1> 
+      {
+        ?person <http://xmlns.com/foaf/0.1/givenName> 'Fred'  ; 
+                                           ?property1 ?value1 . 
+      }
+    GRAPH <urn:sparql:tests:delete:where2> 
+      {
+        ?person ?property2 ?value2 . 
+      }
+  }

--- a/src/keywords.ts
+++ b/src/keywords.ts
@@ -203,17 +203,17 @@ export const keywords = {
 
   INSERT_DATA: createToken({
     name: 'INSERT_DATA',
-    pattern: /Insert Data/i,
+    pattern: /Insert +Data/i,
   }),
 
   DELETE_DATA: createToken({
     name: 'DELETE_DATA',
-    pattern: /Delete Data/i,
+    pattern: /Delete +Data/i,
   }),
 
   DELETE_WHERE: createToken({
     name: 'DELETE_WHERE',
-    pattern: /Delete Where/i,
+    pattern: /Delete +Where/i,
   }),
 
   WITH: createToken({


### PR DESCRIPTION
per rule #7 in the prose above the sparql spec, `The tokens INSERT DATA, DELETE DATA, DELETE WHERE allow any amount of white space between the words. The single space version is used in the grammar for clarity.`