### PR TITLE
Fix W3SpecSparqlParser classname in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ When used in the browser via `script` tags, the API will be exposed on a global 
 Import Millan or the specific parts of Millan that you need, e.g.:
 
 ```javascript
-import { W3CSpecSparqlParser } from 'millan';
+import { W3SpecSparqlParser } from 'millan';
 ```
 
 Parsing a document requires a parser instance, so you should get one:
 
 ```javascript
-const sparqlParser = new W3CSpecSparqlParser();
+const sparqlParser = new W3SpecSparqlParser();
 ```
 
 Every parser instance has essentially the same API. They are all instances of the


### PR DESCRIPTION
The classname of `W3SpecSparqlParser` is incorrect in the example snippets in the README.

Copying/Pasting the snippets yields the following error:
```
error TS2724: '"millan"' has no exported member named 'W3CSpecSparqlParser'. Did you mean 'W3SpecSparqlParser'?
1 import { W3CSpecSparqlParser } from 'millan';
           ~~~~~~~~~~~~~~~~~~~

  node_modules/millan/dist/types/sparql/W3SpecSparqlParser.d.ts:2:22
    2 export declare class W3SpecSparqlParser extends BaseSparqlParser {
```